### PR TITLE
Makes Unicode Parsing Safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 test-files
+*.fsm
+*.json
+*.pseudo.py

--- a/fsm_handling.py
+++ b/fsm_handling.py
@@ -222,6 +222,7 @@ def DataEntry(type):
             13: Float64l,
             14: CString("utf8"),
             15: RGBA(),
+            16: Int64ul, #pointer
             20: Vector3(),
             21: Vector4(),
             22: Quat4()

--- a/fsm_handling.py
+++ b/fsm_handling.py
@@ -9,6 +9,17 @@ from dataclasses import dataclass
 import sys
 import json
 
+def UnicodeSafeDecode(self, obj, context, path):
+    return obj.decode(self.encoding,'ignore')
+    #try:
+    #    return obj.decode(self.encoding)
+    #except:
+    #    origLen = len(obj)
+    #    missingStr = obj.decode(self.encoding,'ignore')
+    #    completedStr = missingStr + "$"*(origLen - len(missingStr.encode("utf-8")))
+    #    return completedStr
+
+StringEncoded._decode = UnicodeSafeDecode
 
 # Queued Pointer Handling
 
@@ -72,7 +83,7 @@ def PrefixedOffset(sizetype, type, offs = 0):
 # Class definition handling
 
 ClassMemberDefinition = Struct(
-    "name" / DataPointer(Int64ul, CString("utf8"), "names"),
+    "name" / DataPointer(Int64ul, CString("utf8"), "names"),#
     "type" / Byte,
     "unkn" / Byte,
     "size" / Byte,


### PR DESCRIPTION
Unicode Parsing might fail because of invalid characters.
Because the game doesn't use the strings and only reads them as raw bytes, valid game fsm might not be loaded into the fsm handling script.
This change monkey patches construct to use error-safe unicode handling.
It will discard invalid unicode characters during parsing instead of simply erroring out.
Some malicious modders have been introducing non-Unicode characters to prevent unpacking of fsm files, this changes enable the script to work again on said files.